### PR TITLE
Fix import error caused by versioning when trio isn't installed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,19 +2,16 @@
 import io
 from setuptools import setup, find_packages
 
-version_tuple = __import__('trio_mysql').VERSION
 
-if version_tuple[3] is not None:
-    version = "%d.%d.%d_%s" % version_tuple
-else:
-    version = "%d.%d.%d" % version_tuple[:3]
+exec(open("trio_mysql/_version.py", encoding="utf-8").read())
+
 
 with io.open('./README.rst', encoding='utf-8') as f:
     readme = f.read()
 
 setup(
     name="trio_mysql",
-    version=version,
+    version=__version__,
     url='https://github.com/python-trio/trio-mysql/',
     author='Matthias Urlichs',
     author_email='matthias@urlichs.de',

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,17 @@ from setuptools import setup, find_packages
 
 exec(open("trio_mysql/_version.py", encoding="utf-8").read())
 
+if VERSION[3] is not None:
+    version = "%d.%d.%d_%s" % VERSION
+else:
+    version = "%d.%d.%d" % VERSION[:3]
 
 with io.open('./README.rst', encoding='utf-8') as f:
     readme = f.read()
 
 setup(
     name="trio_mysql",
-    version=__version__,
+    version=version,
     url='https://github.com/python-trio/trio-mysql/',
     author='Matthias Urlichs',
     author_email='matthias@urlichs.de',

--- a/trio_mysql/__init__.py
+++ b/trio_mysql/__init__.py
@@ -24,6 +24,7 @@ THE SOFTWARE.
 """
 import sys
 
+from ._version import __version__
 from .constants import FIELD_TYPE
 from .converters import escape_dict, escape_sequence, escape_string
 from .err import (
@@ -35,7 +36,7 @@ from .times import (
     DateFromTicks, TimeFromTicks, TimestampFromTicks)
 
 
-VERSION = (0, 8, 0, None)
+VERSION = tuple(__version__.split("."))
 threadsafety = 1
 apilevel = "2.0"
 paramstyle = "pyformat"

--- a/trio_mysql/__init__.py
+++ b/trio_mysql/__init__.py
@@ -24,7 +24,7 @@ THE SOFTWARE.
 """
 import sys
 
-from ._version import __version__
+from ._version import VERSION
 from .constants import FIELD_TYPE
 from .converters import escape_dict, escape_sequence, escape_string
 from .err import (
@@ -36,7 +36,6 @@ from .times import (
     DateFromTicks, TimeFromTicks, TimestampFromTicks)
 
 
-VERSION = tuple(__version__.split("."))
 threadsafety = 1
 apilevel = "2.0"
 paramstyle = "pyformat"

--- a/trio_mysql/_version.py
+++ b/trio_mysql/_version.py
@@ -1,0 +1,3 @@
+# This file is imported from __init__.py and exec'd from setup.py
+
+__version__ = "0.8.0"

--- a/trio_mysql/_version.py
+++ b/trio_mysql/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and exec'd from setup.py
 
-__version__ = "0.8.0"
+VERSION = (0, 8, 0, None)

--- a/trio_mysql/_version.py
+++ b/trio_mysql/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and exec'd from setup.py
 
-VERSION = (0, 8, 0, None)
+VERSION = (0, 8, 1, None)


### PR DESCRIPTION
When trio isn't already installed, pip install/setup.py fails like so:

```
python-myjibake $ pip install -e .
Obtaining file:///home/ninpo/dev/python-myjibake
Collecting click<8.0,>=7.0 (from myjibake==0.post2.dev0+g2b29f4c)
  Using cached https://files.pythonhosted.org/packages/fa/37/45185cb5abbc30d7257104c434fe0b07e5a195a6847506c074527aa599ec/Click-7.0-py2.py3-none-any.whl
Collecting trio>=0.10.0 (from myjibake==0.post2.dev0+g2b29f4c)
  Using cached https://files.pythonhosted.org/packages/e6/20/37be7b5f47db6a9fbf905b5de5386e5b7193c45d07becb750db6f03cd117/trio-0.10.0.tar.gz
  Installing build dependencies ... done
Collecting trio_mysql>=0.8.0 (from myjibake==0.post2.dev0+g2b29f4c)
  Using cached https://files.pythonhosted.org/packages/eb/ee/a24293fae622f068fd62c7fcd2e21b43dc150d622a1838851196584cac99/trio_mysql-0.8.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-5osqv__2/trio-mysql/setup.py", line 5, in <module>
        version_tuple = __import__('trio_mysql').VERSION
      File "/tmp/pip-install-5osqv__2/trio-mysql/trio_mysql/__init__.py", line 91, in <module>
        from . import connections as _orig_conn
      File "/tmp/pip-install-5osqv__2/trio-mysql/trio_mysql/connections.py", line 8, in <module>
        import trio
    ModuleNotFoundError: No module named 'trio'
```