### PR TITLE
fix missing awaits in MySQL 8 auth path

### DIFF
--- a/trio_mysql/_auth.py
+++ b/trio_mysql/_auth.py
@@ -229,7 +229,7 @@ async def caching_sha2_password_auth(conn, pkt):
     if n == 3:
         if DEBUG:
             print("caching sha2: succeeded by fast path.")
-        pkt = conn._read_packet()
+        pkt = await conn._read_packet()
         pkt.check_error()  # pkt must be OK packet
         return pkt
 

--- a/trio_mysql/connections.py
+++ b/trio_mysql/connections.py
@@ -884,9 +884,9 @@ class Connection(object):
                 print("received extra data")
             # https://dev.mysql.com/doc/internals/en/successful-authentication.html
             if self._auth_plugin_name == "caching_sha2_password":
-                auth_packet = _auth.caching_sha2_password_auth(self, auth_packet)
+                auth_packet = await _auth.caching_sha2_password_auth(self, auth_packet)
             elif self._auth_plugin_name == "sha256_password":
-                auth_packet = _auth.sha256_password_auth(self, auth_packet)
+                auth_packet = await _auth.sha256_password_auth(self, auth_packet)
             else:
                 raise err.OperationalError("Received extra packet for auth method %r", self._auth_plugin_name)
 


### PR DESCRIPTION
Please consider merging. Seems like some of the network functions were missed when converting from pymysql. Tested against MySQL 8.0 server. Most of the testcases seems to work fine.