### PR TITLE
Additional test fixes for MySQL 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   include:
     - env:
         - DB=mariadb:5.5
-      python: "3.5"
+      python: "3.6"
     - env:
         - DB=mariadb:10.0
       python: "3.6"
@@ -23,17 +23,17 @@ matrix:
       python: "3.7-dev"
     - env:
         - DB=mysql:5.5
-      python: "3.5"
-    - env:
-        - DB=mysql:5.6
       python: "3.6"
     - env:
+        - DB=mysql:5.6
+      python: "3.7"
+    - env:
         - DB=mysql:5.7
-      python: "3.4"
+      python: "3.8"
     - env:
         - DB=mysql:8.0
         - TEST_AUTH=yes
-      python: "3.7-dev"
+      python: "3.9"
 
 # different py version from 5.6 and 5.7 as cache seems to be based on py version
 # http://dev.mysql.com/downloads/mysql/5.7.html has latest development release version

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,14 +45,6 @@ install:
 before_script:
   - ./.travis/initializedb.sh
   - python -VV
-  - mysql -e 'create database test_trio_mysql  DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'
-  - mysql -e 'create database test_trio_mysql2 DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'
-  - mysql -u root -e "create user travis_pass identified by 'some password'; grant all on test_trio_mysql2.* to travis_pass;"
-  - mysql -u root -e "create user travis_pass@localhost identified by 'some password'; grant all on test_trio_mysql2.* to travis_pass@localhost;"
-  - mysql -u travis_pass -p'some password' -e 'show databases'
-  - mysql -e 'select VERSION()'
-  - python -VV
-  - rm -f ~/.my.cnf # set in .travis.initialize.db.sh for the above commands - we should be using database.json however
   - export COVERALLS_PARALLEL=true
 
 script:

--- a/.travis/docker.json
+++ b/.travis/docker.json
@@ -1,4 +1,4 @@
 [
-    {"host": "127.0.0.1", "port": 3306, "user": "root",  "passwd": "", "db": "test1",  "use_unicode": true, "local_infile": true},
-    {"host": "127.0.0.1", "port": 3306, "user": "test2", "password": "some password", "db": "test2" }
+    {"host": "127.0.0.1", "port": 3306, "user": "root",  "passwd": "", "db": "test_trio_mysql",  "use_unicode": true},
+    {"host": "127.0.0.1", "port": 3306, "user": "travis_pass", "passwd": "some password", "db": "test_trio_mysql2"}
 ]

--- a/.travis/initializedb.sh
+++ b/.travis/initializedb.sh
@@ -54,7 +54,7 @@ if [ ! -z "${DB}" ]; then
     sed -e 's/3306/3307/g' -e 's:/var/run/mysqld/mysqld.sock:/tmp/mysql.sock:g' .travis/database.json > tests/databases.json
     echo -e "[client]\nsocket = /tmp/mysql.sock\n" > "${HOME}"/.my.cnf
 
-    cp .travis/docker.json trio-mysql/tests/databases.json
+    cp .travis/docker.json tests/databases.json
 else
     cat ~/.my.cnf
 

--- a/.travis/initializedb.sh
+++ b/.travis/initializedb.sh
@@ -54,7 +54,7 @@ if [ ! -z "${DB}" ]; then
     sed -e 's/3306/3307/g' -e 's:/var/run/mysqld/mysqld.sock:/tmp/mysql.sock:g' .travis/database.json > tests/databases.json
     echo -e "[client]\nsocket = /tmp/mysql.sock\n" > "${HOME}"/.my.cnf
 
-    cp .travis/docker.json pymysql/tests/databases.json
+    cp .travis/docker.json trio-mysql/tests/databases.json
 else
     cat ~/.my.cnf
 

--- a/.travis/initializedb.sh
+++ b/.travis/initializedb.sh
@@ -4,11 +4,9 @@
 set -x
 #verbose
 set -v
+set -e
 
 if [ ! -z "${DB}" ]; then
-    # disable existing database server in case of accidential connection
-    sudo service mysql stop
-
     docker pull ${DB}
     docker run -it --name=mysqld -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -p 3306:3306 ${DB}
     sleep 10
@@ -50,20 +48,16 @@ if [ ! -z "${DB}" ]; then
     else
         WITH_PLUGIN=''
     fi
-    mysql -S /tmp/mysql.sock -u root -e "create user travis@localhost; create user travis@'%'; grant all on *.* to  travis@localhost WITH GRANT OPTION;grant all on *.* to  travis@'%' WITH GRANT OPTION;"
-    sed -e 's/3306/3307/g' -e 's:/var/run/mysqld/mysqld.sock:/tmp/mysql.sock:g' .travis/database.json > tests/databases.json
-    echo -e "[client]\nsocket = /tmp/mysql.sock\n" > "${HOME}"/.my.cnf
+
+    mysql -e 'create database test_trio_mysql  DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'
+    mysql -e 'create database test_trio_mysql2 DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'
+    mysql -u root -e "create user travis_pass identified by 'some password'; grant all on test_trio_mysql2.* to travis_pass;"
+    mysql -u root -e "create user travis_pass@localhost identified by 'some password'; grant all on test_trio_mysql2.* to travis_pass@localhost;"
+    mysql -u travis_pass -p'some password' -e 'show databases'
+    mysql -e 'select VERSION()'
 
     cp .travis/docker.json tests/databases.json
 else
-    cat ~/.my.cnf
-
-    mysql -e 'select VERSION()'
-    mysql -e 'create database test_trio_mysql DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'
-    mysql -e 'create database test_trio_mysql2 DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'
-
-    mysql -u root -e "create user test2           identified by 'some password'; grant all on test_trio_mysql2.* to test2;"
-    mysql -u root -e "create user test2@localhost identified by 'some password'; grant all on test_trio_mysql2.* to test2@localhost;"
-
-    cp .travis/database.json tests/databases.json
+    echo 'required ${DB} variable unset'
+    exit 1
 fi

--- a/README.rst
+++ b/README.rst
@@ -89,39 +89,44 @@ The following examples make use of a simple table
 
 .. code:: python
 
-    import trio_mysql.cursors
+    import trio
+    import trio_mysql
+    import trio_mysql.cursors 
 
-    # Connect to the database
     connection = trio_mysql.connect(host='localhost',
-                                 user='user',
-                                 password='passwd',
-                                 db='db',
-                                 charset='utf8mb4',
-                                 cursorclass=trio_mysql.cursors.DictCursor)
+                                    user='user',
+                                    password='passwd',
+                                    db='db',
+                                    charset='utf8mb4',
+                                    cursorclass=trio_mysql.cursors.DictCursor)
 
-    async with connection as conn:
-        async with conn.cursor() as cursor:
-            # Create a new record
-            sql = "INSERT INTO `users` (`email`, `password`) VALUES (%s, %s)"
-            await cursor.execute(sql, ('webmaster@python.org', 'very-secret'))
-
-        # connection is not autocommit by default. So you must commit to save
-        # your changes.
-        conn.commit()
-
-        # Alternately, you can set up a transaction:
-        async with conn.transaction():
+    async def main():
+        async with connection as conn:
             async with conn.cursor() as cursor:
                 # Create a new record
                 sql = "INSERT INTO `users` (`email`, `password`) VALUES (%s, %s)"
-                await cursor.execute(sql, ('webmistress@python.org', 'totally-secret'))
+                await cursor.execute(sql, ('webmaster@python.org', 'very-secret'))
 
-        async with conn.cursor() as cursor:
-            # Read a single record
-            sql = "SELECT `id`, `password` FROM `users` WHERE `email`=%s"
-            await cursor.execute(sql, ('webmaster@python.org',))
-            result = await cursor.fetchone()
-            print(result)
+            # Connection is not autocommit by default. So you must commit to save
+            # your changes.
+            await conn.commit()
+
+            # Alternately, you can set up a transaction:
+            async with conn.transaction():
+                async with conn.cursor() as cursor:
+                    # Create a new record
+                    sql = "INSERT INTO `users` (`email`, `password`) VALUES (%s, %s)"
+                    await cursor.execute(sql, ('webmistress@python.org', 'totally-secret'))
+
+            async with conn.cursor() as cursor:
+                # Read a single record
+                sql = "SELECT `id`, `password` FROM `users` WHERE `email`=%s"
+                await cursor.execute(sql, ('webmaster@python.org',))
+                result = await cursor.fetchone()
+                print(result)
+
+    trio.run(main)
+
 
 This example will print:
 

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Requirements
 
 * Python -- one of the following:
 
-  - CPython_ >= 3.5
+  - CPython_ >= 3.6
   - PyPy_ >= 5.5
 
 * MySQL Server -- one of the following:

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
     extras_require={
         "rsa": ["cryptography"],
     },
-    setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     packages=find_packages(exclude=['tests*', 'trio_mysql.tests*']),
     classifiers=[

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -9,8 +9,8 @@ from tests import base
 import pytest
 
 try:
-    import imp
-    reload = imp.reload
+    import importlib
+    reload = importlib.reload
 except AttributeError:
     pass
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -27,7 +27,7 @@ class TestOldIssues(base.TrioMySQLTestCase):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             await c.execute("drop table if exists issue3")
-        await c.execute("create table issue3 (d date, t time, dt datetime, ts timestamp)")
+        await c.execute("create table issue3 (d date, t time, dt datetime, ts timestamp NULL DEFAULT NULL)")
         try:
             await c.execute("insert into issue3 (d, t, dt, ts) values (%s,%s,%s,%s)", (None, None, None, None))
             await c.execute("select d from issue3")
@@ -37,7 +37,7 @@ class TestOldIssues(base.TrioMySQLTestCase):
             await c.execute("select dt from issue3")
             self.assertEqual(None, (await c.fetchone())[0])
             await c.execute("select ts from issue3")
-            self.assertTrue(isinstance((await c.fetchone())[0], datetime.datetime))
+            self.assertEqual(None, (await c.fetchone())[0])
         finally:
             await c.execute("drop table issue3")
 

--- a/trio_mysql/_auth.py
+++ b/trio_mysql/_auth.py
@@ -229,7 +229,7 @@ async def caching_sha2_password_auth(conn, pkt):
     if n == 3:
         if DEBUG:
             print("caching sha2: succeeded by fast path.")
-        pkt = conn._read_packet()
+        pkt = await conn._read_packet()
         pkt.check_error()  # pkt must be OK packet
         return pkt
 

--- a/trio_mysql/_version.py
+++ b/trio_mysql/_version.py
@@ -1,3 +1,3 @@
 # This file is imported from __init__.py and exec'd from setup.py
 
-VERSION = (0, 9, 3, None)
+VERSION = (0, 9, 4, None)

--- a/trio_mysql/connections.py
+++ b/trio_mysql/connections.py
@@ -902,9 +902,9 @@ class Connection(object):
                     raise err.OperationalError(2059, "Authentication plugin '%s'"
                               " not loaded: - %r missing authenticate method" % (plugin_name, type(handler)))
         if plugin_name == b"caching_sha2_password":
-            return _auth.caching_sha2_password_auth(self, auth_packet)
+            return await _auth.caching_sha2_password_auth(self, auth_packet)
         elif plugin_name == b"sha256_password":
-            return _auth.sha256_password_auth(self, auth_packet)
+            return await _auth.sha256_password_auth(self, auth_packet)
         elif plugin_name == b"mysql_native_password":
             data = _auth.scramble_native_password(self.password, auth_packet.read_all())
         elif plugin_name == b"mysql_old_password":

--- a/trio_mysql/connections.py
+++ b/trio_mysql/connections.py
@@ -805,7 +805,7 @@ class Connection(object):
         if self.ssl and self.server_capabilities & CLIENT.SSL:
             await self.write_packet(data_init)
 
-            self._sock = trio.ssl.SSLStream(self._sock, self.ctx, server_hostname=self.host)
+            self._sock = trio.SSLStream(self._sock, self.ctx, server_hostname=self.host)
             await self._sock.do_handshake()
             self._secure = True
 

--- a/trio_mysql/connections.py
+++ b/trio_mysql/connections.py
@@ -884,9 +884,9 @@ class Connection(object):
                 print("received extra data")
             # https://dev.mysql.com/doc/internals/en/successful-authentication.html
             if self._auth_plugin_name == "caching_sha2_password":
-                auth_packet = _auth.caching_sha2_password_auth(self, auth_packet)
+                auth_packet = await _auth.caching_sha2_password_auth(self, auth_packet)
             elif self._auth_plugin_name == "sha256_password":
-                auth_packet = _auth.sha256_password_auth(self, auth_packet)
+                auth_packet = await _auth.sha256_password_auth(self, auth_packet)
             else:
                 raise err.OperationalError("Received extra packet for auth method %r", self._auth_plugin_name)
 


### PR DESCRIPTION
In earlier versions the timestamp column defined without explicit defaults
and NULL would actually yield something like
```
timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
```

MySQL 8 removed the "smart" default and obeys the column definition as
requested. Explicitly specifying default so the tests are consistent.

As for the geo functions, they were deprecated in MySQL 5.7 and removed in MySQL 8 in favor
of their ST_ prefixed sucessors.


